### PR TITLE
(Ch. 1.2.3) Fix PyPI casing and (Ch. 3.5.1) OperatingSystem library name

### DIFF
--- a/website/docs/chapter-01/02_architecture.md
+++ b/website/docs/chapter-01/02_architecture.md
@@ -97,7 +97,7 @@ Recall the technology Robot Framework is built on and the prerequisites for runn
 
 Robot Framework is built on **Python** but is adaptable to other languages and technologies through external libraries.
 To run Robot Framework, an [officially supported version](https://devguide.python.org/versions/) of the **Python interpreter** is required on the machine executing the tests|tasks.
-Typically, Robot Framework and its libraries are installed via the "package installer for Python" (`pip`) from [PyPi.org](https://pypi.org/project/robotframework/), allowing for straightforward installation and setup.
+Typically, Robot Framework and its libraries are installed via the "package installer for Python" (`pip`) from [PyPI](https://pypi.org/project/robotframework/), allowing for straightforward installation and setup.
 Robot Framework itself does not have any external dependencies, but additional third party tools or keyword libraries may require additional installations.
 
 

--- a/website/docs/chapter-03/05_advanced_importing.md
+++ b/website/docs/chapter-03/05_advanced_importing.md
@@ -38,7 +38,7 @@ Understand how transitive imports of resource files and libraries work.
 Let's assume the following libraries and resource files shall be used:
 - **Library**    `A`
 - **Library**    `B`
-- **Library**    `Operating System`
+- **Library**    `OperatingSystem`
 - **Resource**    `tech_keywordsA.resource`
 - **Resource**    `tech_keywordsB.resource`
 - **Resource**    `variables.resource`

--- a/website/docs/chapter-03/05_advanced_importing.md
+++ b/website/docs/chapter-03/05_advanced_importing.md
@@ -50,7 +50,7 @@ The respective files could look like this:
 ```robotframework
 *** Settings ***
 Library    A
-Library    Operating System
+Library    OperatingSystem
 ```
 
 **tech_keywordsB.resource:**


### PR DESCRIPTION
- Fixed PyPi.org → PyPI (PyPI is the official spelling of the Python Package Index) -> ( chapter-01/02_architecture.md ) 
- Fixed library name Operating System → OperatingSystem  ( chapter-03/05_advanced_importing.md ) --> the actual import name is one word 