### PR TITLE
Fix wrong library attribution in the comment for Append To List

### DIFF
--- a/website/docs/chapter-05/02_control_structures.md
+++ b/website/docs/chapter-05/02_control_structures.md
@@ -294,7 +294,7 @@ Get Older Participants
         Log    Participant ${participant.name} is older than 40
         # ^ Logs participant name if age is above the minimum
         Append To List    ${older_participants}    ${participant}
-        # ^ BuiltIn keyword to append a value to a list
+        # ^ Collections keyword to append a value to a list
     END
     RETURN    ${older_participants}
 ```


### PR DESCRIPTION
Append To List is from Collections Library : not BuiltIn Library 

https://robotframework.org/robotframework/latest/libraries/Collections.html#Append%20To%20List

The inline comment in chapter-05/02_control_structures.md:297 says Append To List is a BuiltIn keyword, but it actually belongs to the [Collections](https://robotframework.org/robotframework/latest/libraries/Collections.html#Append%20To%20List) library 

(already imported on line 267 of the same example) ,,  for a learner, could create confusion about which library each keyword comes from.


if the intent was to say it is a built-in keyword ( a keyword that come with RF without installing any other dependency ) and we want to keep this intent, i have two suggestions  : 
-   Standard library keyword to append a value to a list  (not very clear) 
-   built-in ( written this way ) kewyrod to append a value to a list 

